### PR TITLE
Only enable ConnectedLivingSpace config if CLS is installed

### DIFF
--- a/GameData/NehemiahInc/Parts/ExperimentContainer/esc1.cfg
+++ b/GameData/NehemiahInc/Parts/ExperimentContainer/esc1.cfg
@@ -49,13 +49,10 @@ PART
     identifier = OMS ESC 1
     chanceTexture = True
   }
-}
 
-@PART[NE_ESC1]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/ExperimentContainer/esc1.cfg
+++ b/GameData/NehemiahInc/Parts/ExperimentContainer/esc1.cfg
@@ -49,10 +49,13 @@ PART
     identifier = OMS ESC 1
     chanceTexture = True
   }
+}
 
-  MODULE
-  {
-    name = ModuleConnectedLivingSpace
-    passable = true
-  }
+@PART[NE_ESC1]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }

--- a/GameData/NehemiahInc/Parts/ExperimentContainer/esc2.cfg
+++ b/GameData/NehemiahInc/Parts/ExperimentContainer/esc2.cfg
@@ -52,13 +52,10 @@ PART
     name = ExperimentStorage
     identifier = OMS ESC 2/2
   }
-}
 
-@PART[NE_ESC2]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/ExperimentContainer/esc2.cfg
+++ b/GameData/NehemiahInc/Parts/ExperimentContainer/esc2.cfg
@@ -52,10 +52,13 @@ PART
     name = ExperimentStorage
     identifier = OMS ESC 2/2
   }
+}
 
-  MODULE
-  {
-    name = ModuleConnectedLivingSpace
-    passable = true
-  }
+@PART[NE_ESC2]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }

--- a/GameData/NehemiahInc/Parts/ExperimentContainer/esc4.cfg
+++ b/GameData/NehemiahInc/Parts/ExperimentContainer/esc4.cfg
@@ -62,13 +62,10 @@ PART
     name = ExperimentStorage
     identifier = OMS ESC 4/4
   }
-}
 
-@PART[NE_ESC4]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/ExperimentContainer/esc4.cfg
+++ b/GameData/NehemiahInc/Parts/ExperimentContainer/esc4.cfg
@@ -62,10 +62,13 @@ PART
     name = ExperimentStorage
     identifier = OMS ESC 4/4
   }
+}
 
-  MODULE
-  {
-    name = ModuleConnectedLivingSpace
-    passable = true
-  }
+@PART[NE_ESC4]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }

--- a/GameData/NehemiahInc/Parts/KEES/PayloadCarrier/part.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/PayloadCarrier/part.cfg
@@ -47,13 +47,9 @@ PART
 	maxSize = 75
   }
 
-}
-
-@PART[NE_KEES_PC]:FOR[NE_SCIENCE]:NEEDS[ModuleConnectedLivingSpace]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/KEES/PayloadCarrier/part.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/PayloadCarrier/part.cfg
@@ -43,14 +43,17 @@ PART
 
   MODULE
   {
-    name = ModuleConnectedLivingSpace
-    passable = true
-  }
-
-  MODULE
-  {
 	name = KASModuleContainer
 	maxSize = 75
   }
 
+}
+
+@PART[NE_KEES_PC]:FOR[NE_SCIENCE]:NEEDS[ModuleConnectedLivingSpace]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }

--- a/GameData/NehemiahInc/Parts/LabEquipmentContainer/part.cfg
+++ b/GameData/NehemiahInc/Parts/LabEquipmentContainer/part.cfg
@@ -47,13 +47,9 @@ PART
     name = EquipmentRackContainer
   }
 
-}
-
-@PART[NE_Rack_Container]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/LabEquipmentContainer/part.cfg
+++ b/GameData/NehemiahInc/Parts/LabEquipmentContainer/part.cfg
@@ -48,3 +48,12 @@ PART
   }
 
 }
+
+@PART[NE_Rack_Container]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}

--- a/GameData/NehemiahInc/Parts/NE MEP-825/part.cfg
+++ b/GameData/NehemiahInc/Parts/NE MEP-825/part.cfg
@@ -64,24 +64,20 @@ PART
     name = neMEP825Internals
   }
 
-MODULE
-{
+  MODULE
+  {
 	name = ModuleLight
-        lightName = platformLight
+    lightName = platformLight
 	useAnimationDim = false
 	lightBrightenSpeed = 2.5
 	lightDimSpeed = 2.5
 	resourceAmount = 0.01
 	useResources = true
-}
+  }
 
-}
-
-@PART[NE_MEP]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/NE MEP-825/part.cfg
+++ b/GameData/NehemiahInc/Parts/NE MEP-825/part.cfg
@@ -76,3 +76,12 @@ MODULE
 }
 
 }
+
+@PART[NE_MEP]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}

--- a/GameData/NehemiahInc/Parts/NE MPL-600/part.cfg
+++ b/GameData/NehemiahInc/Parts/NE MPL-600/part.cfg
@@ -65,13 +65,10 @@ PART
 
     abbreviation = MPL-600
   }
-}
 
-@PART[NE_MPL]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/NE MPL-600/part.cfg
+++ b/GameData/NehemiahInc/Parts/NE MPL-600/part.cfg
@@ -65,10 +65,13 @@ PART
 
     abbreviation = MPL-600
   }
+}
 
-  MODULE
-  {
-    name = ModuleConnectedLivingSpace
-    passable = true
-  }
+@PART[NE_MPL]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }

--- a/GameData/NehemiahInc/Parts/NE MSL-1000/part.cfg
+++ b/GameData/NehemiahInc/Parts/NE MSL-1000/part.cfg
@@ -71,13 +71,10 @@ PART
   {
     name = neMLS1000Internals
   }
-}
 
-@PART[NE_MSL]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
-{
-    MODULE
-	{
-		name = ModuleConnectedLivingSpace
-		passable = true
-	}
+  MODULE:NEEDS[CONNECTEDLIVINGSPACE]
+  {
+    name = ModuleConnectedLivingSpace
+    passable = true
+  }
 }

--- a/GameData/NehemiahInc/Parts/NE MSL-1000/part.cfg
+++ b/GameData/NehemiahInc/Parts/NE MSL-1000/part.cfg
@@ -71,10 +71,13 @@ PART
   {
     name = neMLS1000Internals
   }
+}
 
-  MODULE
-  {
-    name = ModuleConnectedLivingSpace
-    passable = true
-  }
+@PART[NE_MSL]:FOR[NE_SCIENCE]:NEEDS[CONNECTEDLIVINGSPACE]
+{
+    MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
 }


### PR DESCRIPTION
Prevent errors in KSP.log if CLS is not installed, but requires ModuleManager.