### PR TITLE
Ensure KAS parts are only available if KAS is installed

### DIFF
--- a/GameData/NehemiahInc/Parts/KEES/Experiment/ODC.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/Experiment/ODC.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KAS]
 {
 	name = NE_KEES_ODC
 	module = Part

--- a/GameData/NehemiahInc/Parts/KEES/Experiment/POSA1.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/Experiment/POSA1.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KAS]
 {
 	name = NE_KEES_POSA1
 	module = Part

--- a/GameData/NehemiahInc/Parts/KEES/Experiment/POSA2.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/Experiment/POSA2.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KAS]
 {
 	name = NE_KEES_POSA2
 	module = Part

--- a/GameData/NehemiahInc/Parts/KEES/Experiment/PPMD.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/Experiment/PPMD.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KAS]
 {
 	name = NE_KEES_PPMD
 	module = Part

--- a/GameData/NehemiahInc/Parts/KEES/PEC/part.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/PEC/part.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KAS]
 {
 	name = NE_KEES_PEC
 	module = Part

--- a/GameData/NehemiahInc/Parts/KEES/PayloadCarrier/part.cfg
+++ b/GameData/NehemiahInc/Parts/KEES/PayloadCarrier/part.cfg
@@ -1,4 +1,4 @@
-PART
+PART:NEEDS[KAS]
 {
 	name = NE_KEES_PC
 	module = Part


### PR DESCRIPTION
Hide KEES parts if KAS is not installed, but requires ModuleManager.