### PR TITLE
Ruined KEES experiment does not stay ruined and better status messages.

### DIFF
--- a/Plugin/NE Science/KEESExperiment.cs
+++ b/Plugin/NE Science/KEESExperiment.cs
@@ -34,7 +34,7 @@ namespace NE_Science
 
         private bool docked = false;
 
-        private const string debloyAnimation = "Deploy";
+        private const string deployAnimation = "Deploy";
 
         public PartResource getResource(string name)
         {
@@ -67,7 +67,7 @@ namespace NE_Science
                     Events["DeployExperiment"].active = true;
                     break;
                 case RUNNING:
-                    playAnimation(debloyAnimation, 1f, 1f);
+                    playAnimation(deployAnimation, 1f, 1f);
                     break;
             }
             setEVAconfigForStart(true, 3);
@@ -286,7 +286,7 @@ namespace NE_Science
             Events["DeployExperiment"].active = false;
             ScreenMessages.PostScreenMessage("Location changed mid-experiment! " + part.partInfo.title + " ruined.", 6, ScreenMessageStyle.UPPER_CENTER);
             stopResearch();
-            playAnimation(debloyAnimation, -1, 1);
+            playAnimation(deployAnimation, -1, 1);
             state = NOT_READY;
         }
 
@@ -296,7 +296,7 @@ namespace NE_Science
             Events["DeployExperiment"].active = false;
             ScreenMessages.PostScreenMessage("Warning: " + part.partInfo.title + " has detached from the station without being finalized.", 2, ScreenMessageStyle.UPPER_CENTER);
             stopResearch();
-            playAnimation(debloyAnimation, -1, 1);
+            playAnimation(deployAnimation, -1, 1);
             state = NOT_READY;
         }
 
@@ -312,7 +312,7 @@ namespace NE_Science
                 Events["StartExperiment"].active = false;
                 Events["DeployExperiment"].active = false;
                 state = RUNNING;
-                playAnimation(debloyAnimation, 1, 0);
+                playAnimation(deployAnimation, 1, 0);
                 return true;
         }
 
@@ -322,7 +322,7 @@ namespace NE_Science
                 Events["DeployExperiment"].active = deployChecks(false);
                 state = FINISHED;
                 completed = (float)Planetarium.GetUniversalTime();
-                playAnimation(debloyAnimation, -1, 1);
+                playAnimation(deployAnimation, -1, 1);
         }
 
         public virtual void finalized()

--- a/Plugin/NE Science/KEESExperiment.cs
+++ b/Plugin/NE Science/KEESExperiment.cs
@@ -287,7 +287,7 @@ namespace NE_Science
             ScreenMessages.PostScreenMessage("Location changed mid-experiment! " + part.partInfo.title + " ruined.", 6, ScreenMessageStyle.UPPER_CENTER);
             stopResearch();
             playAnimation(deployAnimation, -1, 1);
-            state = NOT_READY;
+            state = ERROR;
         }
 
         public virtual void undockedRunningExp()

--- a/Plugin/NE Science/KEESExperiment.cs
+++ b/Plugin/NE Science/KEESExperiment.cs
@@ -29,7 +29,7 @@ namespace NE_Science
     public class KEESExperiment : OMSExperiment
     {
 
-         [KSPField(isPersistant = false)]
+        [KSPField(isPersistant = false)]
         public int exposureTimeRequired;
 
         private bool docked = false;

--- a/Plugin/NE Science/KEESExperiment.cs
+++ b/Plugin/NE Science/KEESExperiment.cs
@@ -28,6 +28,10 @@ namespace NE_Science
 {
     public class KEESExperiment : OMSExperiment
     {
+        /* Overload from OMSExperiment */
+        new public string notReadyStatus = "Not installed";
+        new public string readyStatus = "Ready";
+        new public string errorStatus = "Experiment Ruined";
 
         [KSPField(isPersistant = false)]
         public int exposureTimeRequired;


### PR DESCRIPTION
Assumption: A ruined KEES experiment should stay ruined.

It's possible to restart a ruined experiment by removing it from a PEC and putting it back on.
This patch (specifically commit 6941f38: line 290, changed NOT_READY to ERROR) fixes this bug.

Additionally this patch modifies the status messages to make them more sensible for KEES experiments, since they don't require a Lab.