### PR TITLE
Fix off-by-one index error and refactor getTargetBody()

### DIFF
--- a/Plugin/NE Science/KeminiExperimentContract.cs
+++ b/Plugin/NE Science/KeminiExperimentContract.cs
@@ -45,15 +45,8 @@ namespace NE_Science.Contracts
                 return false;
             }
             targetBody = getTargetBody();
-            if (targetBody == null)
-            {
-                NE_Helper.log("Generate Contract: Body null set Kerbin as Target");
-                targetBody = Planetarium.fetch.Home;
-            }
-            else
-            {
-                NE_Helper.log("Generate Contract: Body: " + targetBody.name);
-            }
+            // Assert: targetBody != null
+            NE_Helper.log("Generate Contract: Body: " + targetBody.name);
 
             if (!setTargetExperiment(getTargetExperiment())) return false;
 
@@ -160,11 +153,18 @@ namespace NE_Science.Contracts
             return true;
         }
 
+        /** Return either Kerbin, or a random one out of a list of bodies we have reached. */
         private CelestialBody getTargetBody()
         {
+            CelestialBody ret = null;
             List<CelestialBody> bodies = Contract.GetBodies_Reached(true, false);
-            return bodies[UnityEngine.Random.Range(0, bodies.Count)];
-
+            if (bodies != null && bodies.Count > 0) {
+                ret = bodies [UnityEngine.Random.Range (0, bodies.Count - 1)];
+            } else {
+                ret = Planetarium.fetch.Home;
+            }
+            // ASSERT: ret == Kerbin, or a random planet which we have reached
+            return ret;
         }
 
         public override bool CanBeCancelled()


### PR DESCRIPTION
On a brand-new save, I was getting the following exception:
````
 ArgumentOutOfRangeException: Argument is out of range.
Parameter name: index
  at System.Collections.Generic.List`1[CelestialBody].get_Item (Int32 index) [0x00000] in <filename unknown>:0
  at NE_Science.Contracts.KeminiExperimentContract.getTargetBody () [0x00000] in <filename unknown>:0
  at NE_Science.Contracts.KeminiExperimentContract.Generate () [0x00000] in <filename unknown>:0
...
````
`return bodies[UnityEngine.Random.Range(0, bodies.Count)];`
Array indeces are from 0 to (count-1)
Random.Range(min,max) returns a random integer from min to max _inclusive_.

Following patch fixes this issue, as well as refactoring to ensure getTargetBody() never returns null so client code does not need to perform a null check.