### PR TITLE
Ensure ESC3c pod is a probe and not debris

### DIFF
--- a/GameData/NehemiahInc/Parts/ExperimentContainer/esc3c.cfg
+++ b/GameData/NehemiahInc/Parts/ExperimentContainer/esc3c.cfg
@@ -33,7 +33,9 @@ PART
 	maxTemp = 2900
 	fuelCrossFeed = True
 
-  MODEL
+	vesselType = Probe
+
+    MODEL
   {
     model =  NehemiahInc/Parts/ExperimentContainer/esc3c
     position = 0, 0, 0


### PR DESCRIPTION
Fix for #111 

Also, not entirely sure you want to add a probe part.  It's easy enough to use the ESC-# pods with a standard probe core to make unmanned supply ships.
This probe part needs loads of extra parts (RCS, batteries etc) to make it work properly anyway (eg, stored power is not even enough for a descent), so I'm not sure what the value-add is to have it.