### PR TITLE
Mw bugfix kees pec

### DIFF
--- a/Plugin/NE Science/KEES_PEC.cs
+++ b/Plugin/NE Science/KEES_PEC.cs
@@ -69,14 +69,17 @@ namespace NE_Science
                     {
                         exp = newExp;
                         exp.dockedToPEC(true);
-                    } else if (exp != newExp) {
+                    }
+                    else if (exp != newExp)
+                    {
                         exp.dockedToPEC(false);
                         exp = newExp;
                         exp.dockedToPEC(true);
                     }
                 }
             }
-            if (exp != null) {
+            if (exp != null)
+            {
                 exp.dockedToPEC(false);
                 exp = null;
             }
@@ -85,7 +88,8 @@ namespace NE_Science
         public override void OnUpdate()
         {
             base.OnUpdate();
-            if( vessel != null && !vessel.isEVA && vessel.geeForce > maxGforce) {
+            if( vessel != null && !vessel.isEVA && vessel.geeForce > maxGforce)
+            {
                 part.decouple ();
             }
         }

--- a/Plugin/NE Science/KEES_PEC.cs
+++ b/Plugin/NE Science/KEES_PEC.cs
@@ -84,9 +84,8 @@ namespace NE_Science
         public override void OnUpdate()
         {
             base.OnUpdate();
-            if (vessel.geeForce > maxGforce)
-            {
-                part.decouple();
+            if( vessel != null && !vessel.isEVA && vessel.geeForce > maxGforce) {
+                part.decouple ();
             }
         }
 

--- a/Plugin/NE Science/KEES_PEC.cs
+++ b/Plugin/NE Science/KEES_PEC.cs
@@ -75,7 +75,8 @@ namespace NE_Science
                         exp.dockedToPEC(true);
                     }
                 }
-            } else if (exp != null) {
+            }
+            if (exp != null) {
                 exp.dockedToPEC(false);
                 exp = null;
             }

--- a/Plugin/NE Science/KEES_PEC.cs
+++ b/Plugin/NE Science/KEES_PEC.cs
@@ -30,7 +30,7 @@ namespace NE_Science
         [KSPField(isPersistant = false)]
         public double maxGforce = 2.5;
 
-        private AttachNode node;
+        private AttachNode node = null;
         private KEESExperiment exp = null;
 
         public override void OnStart(PartModule.StartState state)
@@ -44,6 +44,8 @@ namespace NE_Science
                 node = part.attachNodes.First();
             }
 
+            /* Run this as a coroutine so the experiment aborts if the
+             * PEC decouples from the ship. */
             StartCoroutine(checkNode());
         }
 
@@ -63,22 +65,17 @@ namespace NE_Science
                 KEESExperiment newExp = node.attachedPart.GetComponent<KEESExperiment>();
                 if (newExp != null)
                 {
-                    if (exp != null && exp != newExp)
+                    if (exp == null)
                     {
+                        exp = newExp;
+                        exp.dockedToPEC(true);
+                    } else if (exp != newExp) {
                         exp.dockedToPEC(false);
                         exp = newExp;
                         exp.dockedToPEC(true);
                     }
-                    else if (exp == null)
-                    {
-                        exp = newExp;
-                        exp.dockedToPEC(true);
-                    }
-                    return;
                 }
-            }
-            if (exp != null)
-            {
+            } else if (exp != null) {
                 exp.dockedToPEC(false);
                 exp = null;
             }


### PR DESCRIPTION
Bugfix for #115 

Bugfix is in OnUpdate(); the rest is a minor code refactor which can be ignored.

Basically it appears that the decouple() was triggered when a KEES_PEC is removed from a container (possibly a moment of high g-forces?).  This created a phantom duplicate, which caused all sorts of problems in the game.