### PR TITLE
Fix for #115 - additional check to see if we are attached to anything else

### DIFF
--- a/Plugin/NE Science/KEES_PEC.cs
+++ b/Plugin/NE Science/KEES_PEC.cs
@@ -84,7 +84,12 @@ namespace NE_Science
         public override void OnUpdate()
         {
             base.OnUpdate();
-            if (!decoupled && vessel != null && !vessel.isEVA && vessel.geeForce > maxGforce)
+            /* Only perform the max-G check if we are attached to a vessel.
+             * During KAS grab, vessel can be itself or a Kerbal, and we may
+             * get spurious high G's. */
+            bool isVesselShip = part.parent != null && vessel != null && !vessel.isEVA;
+
+            if (!decoupled && isVesselShip && vessel.geeForce > maxGforce)
             {
                 NE_Helper.log("KEES PEC over max G, decouple");
                 decoupled = true;


### PR DESCRIPTION
This fix only fixes the decouple triggering during initial KAS deployment of the PEC.
There are more issues, as detailed in #115.