### PR TITLE
Prevent possible access to null object in getAllLabCrewMembers() from

### DIFF
--- a/Plugin/NE Science/KerbalResearchExperimentData.cs
+++ b/Plugin/NE Science/KerbalResearchExperimentData.cs
@@ -146,10 +146,14 @@ namespace NE_Science
             List<string> members = new List<string>();
             if (state == ExperimentState.INSTALLED || state == ExperimentState.RUNNING)
             {
-                Lab lab = ((LabEquipment)store).getLab();
-                foreach (ProtoCrewMember crewMember in lab.part.protoModuleCrew)
-                {
-                    members.Add(crewMember.name.Trim());
+                try {
+                    Lab lab = ((LabEquipment)store).getLab();
+                    foreach (ProtoCrewMember crewMember in lab.part.protoModuleCrew)
+                    {
+                        members.Add(crewMember.name.Trim());
+                    }
+                } catch(NullReferenceException nre) {
+                    NE_Helper.logError ("getAllLabCrewMembers: nullref!\n" + nre.StackTrace);
                 }
             }
             return members;


### PR DESCRIPTION
corrupting the flight state of an MPL-600 lab.

Issue #124.

This pull request is to provide a piece of preventative code that should stop the MPL-600 from misbehaving in case this issue occurs again.  There are good indications that it was a once-off issue as I could not repro to determine -which- object was the cause.
