### PR TITLE
Mw fix spiu

### DIFF
--- a/Plugin/NE Science/ExperimentData.cs
+++ b/Plugin/NE Science/ExperimentData.cs
@@ -448,27 +448,34 @@ namespace NE_Science
         }
     }
 
-    public class MultiStepExperimentData<T>  : ExperimentData where T : ExperimentStep
+    public abstract class MultiStepExperimentData<T>  : ExperimentData where T : ExperimentStep
     {
         private const string ACTIVE_VALUE = "activeStep";
-        protected T[] steps = new T[1];
+        protected T[] steps = null; // Implementation Class must ensure this is allocated
         private int activeStep = 0;
 
-        protected MultiStepExperimentData(string id, string type, string name, string abb, EquipmentRacks eq, float mass)
+        protected MultiStepExperimentData(string id, string type, string name, string abb, EquipmentRacks eq, float mass, int numSteps)
             : base(id, type, name, abb, eq, mass)
-        { }
+        {
+            if (numSteps < 1) {
+                throw new ArgumentOutOfRangeException ("numSteps", "MultiStepExperimentData must have at least 1 step.");
+            }
+            steps = new T[numSteps];
+        }
 
         public override ConfigNode getNode()
         {
             ConfigNode baseNode = base.getNode();
-            baseNode.AddValue(ACTIVE_VALUE, activeStep);
+            try {
+                baseNode.AddValue(ACTIVE_VALUE, activeStep);
 
-            if (steps != null)
-            {
                 foreach (ExperimentStep es in steps)
                 {
                     baseNode.AddNode(es.getNode());
                 }
+            } catch(NullReferenceException nre) {
+                NE_Helper.logError ("MultiStepExperimentData.getNode - NullReferenceException:\n"
+                                    + nre.StackTrace);
             }
             return baseNode;
         }

--- a/Plugin/NE Science/KerbalResearchExperimentData.cs
+++ b/Plugin/NE Science/KerbalResearchExperimentData.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace NE_Science
 {
-    public class KerbalResearchExperimentData : MultiStepExperimentData<KerbalResearchStep>
+    public abstract class KerbalResearchExperimentData : MultiStepExperimentData<KerbalResearchStep>
     {
         private const string TEST_SUBJECTS_NEEDED = "SubjectsNeeded";
 
@@ -16,10 +16,9 @@ namespace NE_Science
         private List<MPL_Module> physicsLabCache = null;
 
         protected KerbalResearchExperimentData(string id, string type, string name, string abb, EquipmentRacks eq, float mass, int testSubjectsNeeded)
-            : base(id, type, name, abb, eq, mass)
+            : base(id, type, name, abb, eq, mass, testSubjectsNeeded)
         {
             this.testSubjectsNeeded = testSubjectsNeeded;
-            steps = new KerbalResearchStep[testSubjectsNeeded];
         }
 
         public override ConfigNode getNode()
@@ -212,8 +211,10 @@ namespace NE_Science
         { 
         }
 
-        public KerbalResearchStep(ExperimentData exp, string name, int index):base(exp, "KerbalResStep", name, index)
-        { }
+        public KerbalResearchStep(ExperimentData exp, string name, int index)
+            : base(exp, "KerbalResStep", name, index)
+        {
+        }
 
         protected override void load(ConfigNode node)
         {

--- a/Plugin/NE Science/KerbalResearchExperimentData.cs
+++ b/Plugin/NE Science/KerbalResearchExperimentData.cs
@@ -21,6 +21,14 @@ namespace NE_Science
             this.testSubjectsNeeded = testSubjectsNeeded;
         }
 
+        /** Sets up the required number of test subjects */
+        protected void setExperimentSteps(string resourceName, float resourceAmount)
+        {
+            for (int idx = 0; idx < steps.Length; idx++) {
+                steps [idx] = new KerbalResearchStep(this, resourceName, resourceAmount, idx);
+            }
+        }
+
         public override ConfigNode getNode()
         {
             ConfigNode node =  base.getNode();

--- a/Plugin/NE Science/Lab.cs
+++ b/Plugin/NE Science/Lab.cs
@@ -25,7 +25,7 @@ using UnityEngine;
 
 namespace NE_Science
 {
-    public class Lab : PartModule
+    public abstract class Lab : PartModule
     {
 
         [KSPField(isPersistant = false)]

--- a/Plugin/NE Science/MEP_ExperimentData.cs
+++ b/Plugin/NE Science/MEP_ExperimentData.cs
@@ -5,15 +5,15 @@ using System.Text;
 
 namespace NE_Science
 {
-    public class MEPExperimentData : MultiStepExperimentData<MEPResourceExperimentStep>
+    public abstract class MEPExperimentData : MultiStepExperimentData<MEPResourceExperimentStep>
     {
 
         private Guid cachedVesselID;
         private int partCount;
         private List<MEP_Module> physicsLabCache = null;
 
-        protected MEPExperimentData(string id, string type, string name, string abb, EquipmentRacks eq, float mass)
-            : base(id, type, name, abb, eq, mass)
+        protected MEPExperimentData(string id, string type, string name, string abb, EquipmentRacks eq, float mass, int numSteps)
+            : base(id, type, name, abb, eq, mass, numSteps)
         { }
 
         public override List<Lab> getFreeLabsWithEquipment(Vessel vessel)
@@ -52,10 +52,8 @@ namespace NE_Science
     public class MEE1_ExperimentData : MEPExperimentData
     {
         public MEE1_ExperimentData(float mass)
-            : base("NE_MEE1", "MEE1", "Material Exposure Experiment 1", "MEE1", EquipmentRacks.EXPOSURE, mass)
+            : base("NE_MEE1", "MEE1", "Material Exposure Experiment 1", "MEE1", EquipmentRacks.EXPOSURE, mass, 2)
         {
-
-            steps = new MEPResourceExperimentStep[2];
             steps[0] = new MEPResourceExperimentStep(this, Resources.LAB_TIME, 1, "Preparation", 0);
             steps[1] = new MEPResourceExperimentStep(this, Resources.EXPOSURE_TIME, 20, "Exposure", 1);
 
@@ -65,9 +63,8 @@ namespace NE_Science
     public class MEE2_ExperimentData : MEPExperimentData
     {
         public MEE2_ExperimentData(float mass)
-            : base("NE_MEE2", "MEE2", "Material Exposure Experiment 2", "MEE2", EquipmentRacks.EXPOSURE, mass)
+            : base("NE_MEE2", "MEE2", "Material Exposure Experiment 2", "MEE2", EquipmentRacks.EXPOSURE, mass, 3)
         {
-            steps = new MEPResourceExperimentStep[3];
             steps[0] = new MEPResourceExperimentStep(this, Resources.LAB_TIME, 1, "Preparation", 0);
             steps[1] = new MEPResourceExperimentStep(this, Resources.EXPOSURE_TIME, 40, "Exposure", 1);
             steps[2] = new MEPResourceExperimentStep(this, Resources.LAB_TIME, 2, "Store Samples", 2);

--- a/Plugin/NE Science/MEP_ExperimentData.cs
+++ b/Plugin/NE Science/MEP_ExperimentData.cs
@@ -16,6 +16,12 @@ namespace NE_Science
             : base(id, type, name, abb, eq, mass, numSteps)
         { }
 
+        /** Sets up the required number of test subjects */
+        protected void setExperimentStep(string resourceName, float resourceAmount, string stepName, int index)
+        {
+            steps[index]= new MEPResourceExperimentStep(this, resourceName, resourceAmount, stepName, index);
+        }
+
         public override List<Lab> getFreeLabsWithEquipment(Vessel vessel)
         {
             List<Lab> ret = new List<Lab>();
@@ -54,9 +60,8 @@ namespace NE_Science
         public MEE1_ExperimentData(float mass)
             : base("NE_MEE1", "MEE1", "Material Exposure Experiment 1", "MEE1", EquipmentRacks.EXPOSURE, mass, 2)
         {
-            steps[0] = new MEPResourceExperimentStep(this, Resources.LAB_TIME, 1, "Preparation", 0);
-            steps[1] = new MEPResourceExperimentStep(this, Resources.EXPOSURE_TIME, 20, "Exposure", 1);
-
+            setExperimentStep(Resources.LAB_TIME, 1, "Preparation", 0);
+            setExperimentStep(Resources.EXPOSURE_TIME, 20, "Exposure", 1);
         }
     }
 
@@ -65,9 +70,9 @@ namespace NE_Science
         public MEE2_ExperimentData(float mass)
             : base("NE_MEE2", "MEE2", "Material Exposure Experiment 2", "MEE2", EquipmentRacks.EXPOSURE, mass, 3)
         {
-            steps[0] = new MEPResourceExperimentStep(this, Resources.LAB_TIME, 1, "Preparation", 0);
-            steps[1] = new MEPResourceExperimentStep(this, Resources.EXPOSURE_TIME, 40, "Exposure", 1);
-            steps[2] = new MEPResourceExperimentStep(this, Resources.LAB_TIME, 2, "Store Samples", 2);
+            setExperimentStep(Resources.LAB_TIME, 1, "Preparation", 0);
+            setExperimentStep(Resources.EXPOSURE_TIME, 40, "Exposure", 1);
+            setExperimentStep(Resources.LAB_TIME, 2, "Store Samples", 2);
         }
     }
 }

--- a/Plugin/NE Science/MPL_ExperimentData.cs
+++ b/Plugin/NE Science/MPL_ExperimentData.cs
@@ -75,10 +75,7 @@ namespace NE_Science
         public ADUM_ExperimentData(float mass)
             : base("NE_ADUM", "ADUM", "Advanced Diagnostic Ultrasound in Microgravity", "ADUM", EquipmentRacks.USU, mass, 4)
         {
-            steps[0] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 2.5f, 0);
-            steps[1] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 2.5f, 1);
-            steps[2] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 2.5f, 2);
-            steps[3] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 2.5f, 3);
+            setExperimentSteps(Resources.ULTRASOUND_GEL, 2.5f);
         }
     }
 
@@ -87,12 +84,7 @@ namespace NE_Science
         public SpiU_ExperimentData(float mass)
             : base("NE_SpiU", "SpiU", "Sonographic Astronaut Vertebral Examination", "SpiU", EquipmentRacks.USU, mass, 6)
         {
-            steps[0] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 0);
-            steps[1] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 1);
-            steps[2] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 2);
-            steps[3] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 3);
-            steps[4] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 4);
-            steps[5] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 5);
+            setExperimentSteps(Resources.ULTRASOUND_GEL, 3f);
         }
     }
 }

--- a/Plugin/NE Science/MPL_ExperimentData.cs
+++ b/Plugin/NE Science/MPL_ExperimentData.cs
@@ -91,8 +91,8 @@ namespace NE_Science
             steps[1] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 1);
             steps[2] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 2);
             steps[3] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 3);
-            steps[4] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 3);
-            steps[5] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 3);
+            steps[4] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 4);
+            steps[5] = new KerbalResearchStep(this, Resources.ULTRASOUND_GEL, 3f, 5);
         }
     }
 }


### PR DESCRIPTION
Fix for #127.
SpiU experiment was broken - copy and paste error in experiment configuration meant only 4 steps were saved.  Steps 5 & 6 were NULL, causing NullReferneceExceptions to be thrown.
